### PR TITLE
Add 'dataFromLiteral' to ExternalSecret API

### DIFF
--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -73,6 +73,20 @@ spec:
                   type: array
                   items:
                     type: string
+                dataFromLiteral:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - value
+                    properties:
+                      name:
+                        description: Name set for this key in the generated secret
+                        type: string
+                      value:
+                        description: Non-sensitive value to be set for the name of this secret field
+                        type: string
                 data:
                   type: array
                   items:

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -113,6 +113,24 @@ class KVBackend extends AbstractBackend {
   }
 
   /**
+   * Generate Kubernetes secret property values.
+   * @param {Object[]} dataFromLiteral - Kubernetes secret properties.
+   * @param {string} dataFromLiteral[].name - Kubernetes Secret property name.
+   * @param {string} dataFromLiteral[].value - Non-sensitive value to associate with the
+   *    name.
+   * @returns {Promise} Promise object representing secret property values.
+   */
+  _fetchDataFromLiteralValues ({ dataFromLiteral }) {
+    return Promise.all(dataFromLiteral.map(async dataItem => {
+      const { name, value } = dataItem
+
+      const response = { [name]: value }
+
+      return response
+    }))
+  }
+
+  /**
    * Get a secret property value from Key Value backend.
    * @param {string} key - Secret key in the backend.
    * @param {string} keyOptions - Options for this specific key, eg version etc.
@@ -162,15 +180,17 @@ class KVBackend extends AbstractBackend {
       properties = [],
       data = properties,
       dataFrom = [],
+      dataFromLiteral = [],
       ...specOptions
     }
   }) {
-    const [dataFromValues, dataValues] = await Promise.all([
+    const [dataFromLiteralValues, dataFromValues, dataValues] = await Promise.all([
+      this._fetchDataFromLiteralValues({ dataFromLiteral }),
       this._fetchDataFromValues({ dataFrom, specOptions }),
       this._fetchDataValues({ data, specOptions })
     ])
 
-    const plainValues = dataFromValues.concat(dataValues)
+    const plainValues = dataFromLiteralValues.concat(dataFromValues).concat(dataValues)
       .reduce((acc, parsedValue) => ({
         ...acc,
         ...parsedValue

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -267,6 +267,25 @@ describe('kv-backend', () => {
     })
   })
 
+  describe('_fetchDataFromLiteralValues', () => {
+    it('handles key value pairs', async () => {
+      const dataFromValues = await kvBackend._fetchDataFromLiteralValues({
+        dataFromLiteral: [
+          {
+            name: 'foo',
+            value: 'bar'
+          },
+          {
+            name: 'bar',
+            value: 'foo'
+          }
+        ]
+      }
+      )
+      expect(dataFromValues).to.deep.equal([{ foo: 'bar' }, { bar: 'foo' }])
+    })
+  })
+
   describe('_get', () => {
     it('throws an error', () => {
       let error
@@ -309,7 +328,18 @@ describe('kv-backend', () => {
 
       const manifestData = await kvBackend
         .getSecretManifestData({
-          spec: { }
+          spec: {
+            dataFromLiteral: [
+              {
+                name: 'fakePropertyName6',
+                value: 'fakePropertyValue6'
+              },
+              {
+                name: 'fakePropertyName7',
+                value: 'fakePropertyValue7'
+              }
+            ]
+          }
         })
 
       expect(manifestData).deep.equals({
@@ -318,7 +348,9 @@ describe('kv-backend', () => {
         fakePropertyName2: 'ZmFrZVByb3BlcnR5VmFsdWUy', // base 64 value of fakePropertyValue2
         fakePropertyName3: 'ZmFrZVByb3BlcnR5VmFsdWUz', // base 64 value of fakePropertyValue3
         fakePropertyName4: 'ZmFrZVByb3BlcnR5VmFsdWU0', // base 64 value of fakePropertyValue4
-        fakePropertyName5: 'ZmFrZVByb3BlcnR5VmFsdWU1' // base 64 value of fakePropertyValue5
+        fakePropertyName5: 'ZmFrZVByb3BlcnR5VmFsdWU1', // base 64 value of fakePropertyValue5
+        fakePropertyName6: 'ZmFrZVByb3BlcnR5VmFsdWU2', // base 64 value of fakePropertyValue6
+        fakePropertyName7: 'ZmFrZVByb3BlcnR5VmFsdWU3' // base 64 value of fakePropertyValue7
       })
     })
 


### PR DESCRIPTION
I have a use case where I need a Kubernetes secret which contains a file
meant to be mounted to a container. In this file there is sensitive data
so it must be templated using the `spec.template.stringData`
functionality. Within this file there is also recurring, non-sensitive,
data that would benefit from being templated.

More specifically, I had a dozen references to a GCP project ID which
would need to be hard coded in that many locations.

I tried to supply this within the `spec.template.stringData`, but
expectedly, that data is not part of the map which renders the template;
only `spec.data` and `spec.dataFrom` are merged for that.

It would be possible to use Helm to fill Golang templates within the
lodash template, however, if feels like a bad practice to have 2
templating patterns operating on the same data.

This led me to introduce the `dataFromLiteral` key-value pairing for the
abstract kvbackend so all backends can template non-sensitive data along
side their sensitive, cloud secrets.